### PR TITLE
[removed] modal moudle unuseful code

### DIFF
--- a/src/js/module/modal.html
+++ b/src/js/module/modal.html
@@ -1,4 +1,4 @@
-<div class="m-modal {class}" on-keyup={this._onKeyUp($event)} r-hide={!visible}>
+<div class="m-modal {class}" r-hide={!visible}>
     <div class="modal_dialog" ref="modalDialog">
         <draggable disabled={!draggable} proxy={this.$refs.modalDialog} on-dragstart={this._onDragStart($event)}>
         <div class="modal_hd">

--- a/src/js/module/modal.js
+++ b/src/js/module/modal.js
@@ -92,13 +92,6 @@ var Modal = Component.extend({
 
         this.destroy();
     },
-    /**
-     * @private
-     */
-    _onKeyUp: function($event) {
-        if($event.which == 13)
-            this.ok();
-    },
     _onDragStart: function($event) {
         var dialog = $event.proxy;
         dialog.style.left = dialog.offsetLeft + 'px';


### PR DESCRIPTION
[removed] modal moudle unuseful code
这里的onkeyup事件根本不会触发，_onKeyUp函数也不会执行，button自动聚焦后回车的默认行为就是触发click，所以去除下这里的冗余代码。